### PR TITLE
chore: update copyright year to 2021

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-                                 Apache License
+                                Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
 
@@ -178,7 +178,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
+      boilerplate notice, with the fields enclosed by brackets "{}"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright (c) 2021 Target Brands, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Please see our [support](.github/SUPPORT.md) documentation for further instructi
 ## Copyright and License
 
 ```
-Copyright (c) 2020 Target Brands, Inc.
+Copyright (c) 2021 Target Brands, Inc.
 ```
 
 [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/generate/README.md
+++ b/generate/README.md
@@ -11,5 +11,4 @@ Then ensure you have the swagger-codegen command installed:
 Then run:
 
 `swagger-codegen generate -c config.json -l python -i vela.json -o vela
-find vela -name \*.py -exec sed -i 's/# coding: utf-8/# coding: utf-8\n#\n# Copyright (c) 2020 Target Brands, Inc. All rights reserved./' \{\} +`
-
+find vela -name \*.py -exec sed -i 's/# coding: utf-8/# coding: utf-8\n#\n# Copyright (c) 2021 Target Brands, Inc. All rights reserved./' \{\} +`

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_admin_api.py
+++ b/test/test_admin_api.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_authenticate_api.py
+++ b/test/test_authenticate_api.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_builds_api.py
+++ b/test/test_builds_api.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_container.py
+++ b/test/test_container.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_container_slice.py
+++ b/test/test_container_slice.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_deployment_api.py
+++ b/test/test_deployment_api.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_executor.py
+++ b/test/test_executor.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_login.py
+++ b/test/test_login.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_pipeline_build.py
+++ b/test/test_pipeline_build.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_pipeline_metadata.py
+++ b/test/test_pipeline_metadata.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_pipeline_worker.py
+++ b/test/test_pipeline_worker.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_pipelines_api.py
+++ b/test/test_pipelines_api.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_repos_api.py
+++ b/test/test_repos_api.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_router_api.py
+++ b/test/test_router_api.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_rules.py
+++ b/test/test_rules.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_ruleset.py
+++ b/test/test_ruleset.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_ruletype.py
+++ b/test/test_ruletype.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_secret.py
+++ b/test/test_secret.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_secret_slice.py
+++ b/test/test_secret_slice.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_secrets_api.py
+++ b/test/test_secrets_api.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_services_api.py
+++ b/test/test_services_api.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_stage.py
+++ b/test/test_stage.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_stage_slice.py
+++ b/test/test_stage_slice.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_step.py
+++ b/test/test_step.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_step_secret.py
+++ b/test/test_step_secret.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_step_secret_slice.py
+++ b/test/test_step_secret_slice.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_steps_api.py
+++ b/test/test_steps_api.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_template.py
+++ b/test/test_template.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_ulimit.py
+++ b/test/test_ulimit.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_ulimit_slice.py
+++ b/test/test_ulimit_slice.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_users_api.py
+++ b/test/test_users_api.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_volume.py
+++ b/test/test_volume.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_volume_slice.py
+++ b/test/test_volume_slice.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_webhook.py
+++ b/test/test_webhook.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_webhook_api.py
+++ b/test/test_webhook_api.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_worker.py
+++ b/test/test_worker.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/test/test_workers_api.py
+++ b/test/test_workers_api.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/__init__.py
+++ b/vela/__init__.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 # flake8: noqa
 

--- a/vela/api_client.py
+++ b/vela/api_client.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 """
     Vela server
 

--- a/vela/configuration.py
+++ b/vela/configuration.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/__init__.py
+++ b/vela/models/__init__.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 # flake8: noqa
 """

--- a/vela/models/build.py
+++ b/vela/models/build.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/container.py
+++ b/vela/models/container.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/container_slice.py
+++ b/vela/models/container_slice.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/deployment.py
+++ b/vela/models/deployment.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/executor.py
+++ b/vela/models/executor.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/log.py
+++ b/vela/models/log.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/login.py
+++ b/vela/models/login.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/pipeline_build.py
+++ b/vela/models/pipeline_build.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/pipeline_metadata.py
+++ b/vela/models/pipeline_metadata.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/pipeline_worker.py
+++ b/vela/models/pipeline_worker.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/repo.py
+++ b/vela/models/repo.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/rules.py
+++ b/vela/models/rules.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/ruleset.py
+++ b/vela/models/ruleset.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/ruletype.py
+++ b/vela/models/ruletype.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/secret.py
+++ b/vela/models/secret.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/secret_slice.py
+++ b/vela/models/secret_slice.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/service.py
+++ b/vela/models/service.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/stage.py
+++ b/vela/models/stage.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/stage_slice.py
+++ b/vela/models/stage_slice.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/step.py
+++ b/vela/models/step.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/step_secret.py
+++ b/vela/models/step_secret.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/step_secret_slice.py
+++ b/vela/models/step_secret_slice.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/template.py
+++ b/vela/models/template.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/ulimit.py
+++ b/vela/models/ulimit.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/ulimit_slice.py
+++ b/vela/models/ulimit_slice.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/user.py
+++ b/vela/models/user.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/volume.py
+++ b/vela/models/volume.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/volume_slice.py
+++ b/vela/models/volume_slice.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/webhook.py
+++ b/vela/models/webhook.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/models/worker.py
+++ b/vela/models/worker.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/rest.py
+++ b/vela/rest.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/vela/admin_api.py
+++ b/vela/vela/admin_api.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/vela/authenticate_api.py
+++ b/vela/vela/authenticate_api.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/vela/builds_api.py
+++ b/vela/vela/builds_api.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/vela/deployment_api.py
+++ b/vela/vela/deployment_api.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/vela/pipelines_api.py
+++ b/vela/vela/pipelines_api.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/vela/repos_api.py
+++ b/vela/vela/repos_api.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/vela/router_api.py
+++ b/vela/vela/router_api.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/vela/secrets_api.py
+++ b/vela/vela/secrets_api.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/vela/services_api.py
+++ b/vela/vela/services_api.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/vela/steps_api.py
+++ b/vela/vela/steps_api.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/vela/users_api.py
+++ b/vela/vela/users_api.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/vela/webhook_api.py
+++ b/vela/vela/webhook_api.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server

--- a/vela/vela/workers_api.py
+++ b/vela/vela/workers_api.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 
 """
     Vela server


### PR DESCRIPTION
This is a general housekeeping task.

I used VS code's search and replace:

* Search: `Copyright (c) 2020`
* Replace: `Copyright (c) 2021`

At the top of every file, the new copyright statement now looks like:

```
# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
```